### PR TITLE
Update 2.1.1

### DIFF
--- a/SteamAccCreator/Gui/MainForm.Designer.cs
+++ b/SteamAccCreator/Gui/MainForm.Designer.cs
@@ -146,7 +146,6 @@ namespace SteamAccCreator.Gui
             this.Button = new System.Windows.Forms.DataGridViewButtonColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BsProfileConfig = new System.Windows.Forms.BindingSource(this.components);
-            this.BsCaptchaTwoCapConfig = new System.Windows.Forms.BindingSource(this.components);
             this.BsCaptchaCapsolConfig = new System.Windows.Forms.BindingSource(this.components);
             this.enabledDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.Status = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -164,6 +163,8 @@ namespace SteamAccCreator.Gui
             this.passwordDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SteamId = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.statusDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.CbCapTwoCaptchaProxy = new System.Windows.Forms.CheckBox();
+            this.BsCaptchaTwoCapConfig = new System.Windows.Forms.BindingSource(this.components);
             this.pnlCreation.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DgvAccounts)).BeginInit();
             this.tabControl.SuspendLayout();
@@ -183,11 +184,11 @@ namespace SteamAccCreator.Gui
             this.tabUpdates.SuspendLayout();
             this.tabAbout.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.BsProfileConfig)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaTwoCapConfig)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaCapsolConfig)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsProxyItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsModules)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsAccount)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaTwoCapConfig)).BeginInit();
             this.SuspendLayout();
             // 
             // txtEmail
@@ -924,6 +925,7 @@ namespace SteamAccCreator.Gui
             // 
             // GbCapTwoCaptcha
             // 
+            this.GbCapTwoCaptcha.Controls.Add(this.CbCapTwoCaptchaProxy);
             this.GbCapTwoCaptcha.Controls.Add(this.CbCapTwoCaptchaReportBad);
             this.GbCapTwoCaptcha.Controls.Add(this.LbCapTwoCaptchaKey);
             this.GbCapTwoCaptcha.Controls.Add(this.TbCapTwoCaptchaKey);
@@ -1635,10 +1637,6 @@ namespace SteamAccCreator.Gui
             // 
             this.BsProfileConfig.DataSource = typeof(SteamAccCreator.Models.ProfileConfig);
             // 
-            // BsCaptchaTwoCapConfig
-            // 
-            this.BsCaptchaTwoCapConfig.DataSource = typeof(SteamAccCreator.Models.RuCaptchaConfig);
-            // 
             // BsCaptchaCapsolConfig
             // 
             this.BsCaptchaCapsolConfig.DataSource = typeof(SteamAccCreator.Models.CaptchaSolutionsConfig);
@@ -1777,6 +1775,21 @@ namespace SteamAccCreator.Gui
             this.statusDataGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.statusDataGridViewTextBoxColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
+            // CbCapTwoCaptchaProxy
+            // 
+            this.CbCapTwoCaptchaProxy.AutoSize = true;
+            this.CbCapTwoCaptchaProxy.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.BsCaptchaTwoCapConfig, "TransferProxy", true));
+            this.CbCapTwoCaptchaProxy.Location = new System.Drawing.Point(154, 45);
+            this.CbCapTwoCaptchaProxy.Name = "CbCapTwoCaptchaProxy";
+            this.CbCapTwoCaptchaProxy.Size = new System.Drawing.Size(101, 17);
+            this.CbCapTwoCaptchaProxy.TabIndex = 3;
+            this.CbCapTwoCaptchaProxy.Text = "Transfer proxies";
+            this.CbCapTwoCaptchaProxy.UseVisualStyleBackColor = true;
+            // 
+            // BsCaptchaTwoCapConfig
+            // 
+            this.BsCaptchaTwoCapConfig.DataSource = typeof(SteamAccCreator.Models.RuCaptchaConfig);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1821,11 +1834,11 @@ namespace SteamAccCreator.Gui
             this.tabAbout.ResumeLayout(false);
             this.tabAbout.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.BsProfileConfig)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaTwoCapConfig)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaCapsolConfig)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsProxyItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsModules)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BsAccount)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.BsCaptchaTwoCapConfig)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -1962,6 +1975,7 @@ namespace SteamAccCreator.Gui
         private System.Windows.Forms.DataGridViewTextBoxColumn SteamId;
         private System.Windows.Forms.DataGridViewTextBoxColumn statusDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
+        private System.Windows.Forms.CheckBox CbCapTwoCaptchaProxy;
     }
 }
 

--- a/SteamAccCreator/Models/RuCaptchaConfig.cs
+++ b/SteamAccCreator/Models/RuCaptchaConfig.cs
@@ -9,5 +9,7 @@ namespace SteamAccCreator.Models
     {
         public string ApiKey { get; set; } = "";
         public bool ReportBad { get; set; } = false;
+
+        public bool TransferProxy { get; set; } = true;
     }
 }

--- a/SteamAccCreator/Program.cs
+++ b/SteamAccCreator/Program.cs
@@ -118,6 +118,10 @@ Latest versions will be here: https://github.com/EarsKilla/Steam-Account-Generat
                 (m) => true,
                 Web.Steam.SteamWebClient.DisableLegitDelay);
 
+            Web.Account.SkipSteamGuardDisable = Utility.GetStartOption(@"-skip(Steam)?Guard",
+                (m) => true,
+                Web.Account.SkipSteamGuardDisable);
+
             var noStylesOpt = Utility.HasStartOption("-nostyles");
             if (!noStylesOpt)
             {

--- a/SteamAccCreator/Program.cs
+++ b/SteamAccCreator/Program.cs
@@ -146,6 +146,7 @@ Latest versions will be here: https://github.com/EarsKilla/Steam-Account-Generat
                 $"Count of mail checks in hand mode: {Web.Mail.MailHandler.CheckUserMailVerifyCount}\n" +
                 $"Count of mail checks in auto mode: {Web.Mail.MailHandler.CheckRandomMailVerifyCount}\n" +
                 $"Disable \"legit\" delays between Steam requests: {(Web.Steam.SteamWebClient.DisableLegitDelay ? "Yes" : "No")}\n" +
+                $"Skip disabling Steam guard: {(Web.Account.SkipSteamGuardDisable ? "Yes" : "No")}\n" +
                 $"NoStyles: {(noStylesOpt ? "Yes" : "No")}\n" +
                 $"Default text render: {(defTextRenderOpt ? "Yes" : "No")}\n" +
                 "######################################");

--- a/SteamAccCreator/Web/Account.cs
+++ b/SteamAccCreator/Web/Account.cs
@@ -1037,7 +1037,7 @@ namespace SteamAccCreator.Web
 
             var tfDisable = response.HttpResponses.Last();
             if (!Regex.IsMatch(tfDisable?.Content ?? "", @"phone_box", RegexOptions.IgnoreCase))
-                return (false, true);
+                return (false, false); //thonk... old: (false, true)
 
             var _status = (MailBoxResponse == null)
                 ? "Waiting for your confirmation..."

--- a/SteamAccCreator/Web/Captcha/Handlers/RuCaptchaHandler.cs
+++ b/SteamAccCreator/Web/Captcha/Handlers/RuCaptchaHandler.cs
@@ -57,6 +57,9 @@ namespace SteamAccCreator.Web.Captcha.Handlers
             if (proxy == null)
                 return;
 
+            if (!Config.TransferProxy)
+                return;
+
             request.AddParameter("proxy", $"{proxy.Host}:{proxy.Port}");
             request.AddParameter("proxytype", (proxy.Type == ProxyType.Unknown) ? "HTTP" : proxy.Type.ToString().ToUpper());
         }

--- a/SteamAccCreator/Web/ErrorMessages.cs
+++ b/SteamAccCreator/Web/ErrorMessages.cs
@@ -78,6 +78,8 @@
 
             public const string TF_FAILED_TO_DISABLE = "Failed to disable SteamGuard!";
             public const string TF_FAILED_TO_DISABLE_FATAL = "Cannot disable SteamGuard!";
+            public const string TF_FAILED_TO_ENABLE = "Failed to enable SteamGuard!";
+            public const string TF_FAILED_TO_ENABLE_FATAL = "Cannot enable SteamGuard!";
             public const string TF_LOAD_LINK_FAILED = "|Steam guard| Failed to load data from confirmation link!";
             public const string TF_LOAD_LINK_FAILED_FATAL = "|Steam guard| Something went wrong while loading data from link!";
             public const string TF_SEARCH_MESSAGE_ERROR = "|Steam guard| Something went wrong while searching message from Steam...";

--- a/SteamAccCreator/Web/ProxyManager.cs
+++ b/SteamAccCreator/Web/ProxyManager.cs
@@ -108,6 +108,8 @@ namespace SteamAccCreator.Web
             Action onGood,
             Action onDone)
         {
+            const int MAX_THREADS = 200;
+
             var proxies = Proxies.ToList();
 
             var threadEndCb = new Action<Thread>((t) =>
@@ -183,12 +185,12 @@ namespace SteamAccCreator.Web
 
             await Task.Factory.StartNew(async () =>
             {
-                var thrs = new List<Thread>(10);
+                var thrs = new List<Thread>(MAX_THREADS);
                 while (CheckThreads.Count > 0)
                 {
                     lock (ThreadsSync)
                     {
-                        var _thrs = CheckThreads.Take(10 - thrs.Count);
+                        var _thrs = CheckThreads.Take(MAX_THREADS - thrs.Count);
                         thrs.AddRange(_thrs);
 
                         for (int i = thrs.Count - 1; i > -1; i--)

--- a/SteamAccCreator/Web/Steam/TwoFactor/SteamTwoFactor.cs
+++ b/SteamAccCreator/Web/Steam/TwoFactor/SteamTwoFactor.cs
@@ -16,6 +16,21 @@ namespace SteamAccCreator.Web.Steam.TwoFactor
             return Execute(request);
         }
 
+        private SteamResponse<string> SetAuthToMail()
+        {
+            var request = new RestRequest(SteamDefaultUrls.TF_MANAGE_ACTION, Method.POST);
+            request.AddParameter("action", "email");
+            request.AddParameter("sessionid", Steam.SessionId);
+            request.AddParameter("email_authenticator_check", "on");
+
+            request.AddHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
+            request.AddHeader("Referer", SteamDefaultUrls.TF_MANAGE);
+
+            var response = Execute(request);
+            return new SteamResponse<string>(response.Content, response);
+        }
+
         private SteamResponse<string> SetAuthToNone()
         {
             var request = new RestRequest(SteamDefaultUrls.TF_MANAGE_ACTION, Method.POST);
@@ -43,6 +58,24 @@ namespace SteamAccCreator.Web.Steam.TwoFactor
 
             var response = Execute(request);
             return new SteamResponse<string>(response.Content, response);
+        }
+
+        public SteamResponse<bool> TurnOnByMail()
+        {
+            var responses = new List<IRestResponse>();
+
+            var requestMagage = GetManage();
+            responses.Add(requestMagage);
+            if (!requestMagage.IsSuccessful)
+                return new SteamResponse<bool>(false, responses);
+
+            Steam.LegitDelay();
+
+            var requestMailAuth = SetAuthToMail();
+            if (!requestMailAuth.IsSuccess)
+                return new SteamResponse<bool>(false, responses);
+
+            return new SteamResponse<bool>(true, responses);
         }
 
         public SteamResponse<bool> TurnOff()


### PR DESCRIPTION
- Proxy manager
  - Increased count of threads for proxy tester. To 200.
- Main
  - Don't stop when Steam Guard failed to disable if it was not fatal and try to update profile and upload photo
  - Possibility to disable passing proxy to Two/RuCaptcha service
  - Launch option to skip SteamGuard disabling
  - Profile.Enabled property respect when updating profile information and photo
  - Issue #49 probably fixed